### PR TITLE
fix blog heading font weights

### DIFF
--- a/src/pages/blog/CreativeGifDesignTutorial.jsx
+++ b/src/pages/blog/CreativeGifDesignTutorial.jsx
@@ -119,7 +119,7 @@ export default function CreativeGifDesignTutorial() {
               Technical execution of cinemagraphs involves complex compositing techniques, motion isolation, and seamless looping that requires frame-perfect precision. However, the conceptual planning phase often determines success more than technical execution. Identifying compelling motion opportunities, understanding viewing context, and planning for seamless loops must occur before any technical work begins.
             </p>
 
-            <h3 className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Typography and Text Animation</h3>
+            <h3 className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Typography and Text Animation</h3>
             <p>
               Animated typography in GIFs serves both functional and aesthetic purposes, providing information while contributing to overall visual impact. Effective text animation techniques include kinetic typography that emphasizes meaning through motion, revealing animations that build suspense, and decorative effects that enhance visual appeal without compromising readability.
             </p>
@@ -155,7 +155,7 @@ export default function CreativeGifDesignTutorial() {
               Asset management and version control become crucial for complex projects involving multiple iterations, team collaboration, and client feedback cycles. Organized file structures, naming conventions, and backup procedures protect creative work while enabling efficient collaboration and project management across different team members and project phases.
             </p>
 
-            <h3 className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Quality Control and Optimization</h3>
+            <h3 className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Quality Control and Optimization</h3>
             <p>
               Creative excellence requires systematic quality control that evaluates both artistic and technical aspects of finished work. Quality metrics include visual appeal, message clarity, technical performance, cross-platform compatibility, and audience engagement potential. Establishing clear quality standards helps maintain consistency while identifying areas for improvement and skill development.
             </p>
@@ -173,7 +173,7 @@ export default function CreativeGifDesignTutorial() {
               Platform-specific creative strategies involve adapting core creative concepts to different aspect ratios, file size limits, and audience expectations while maintaining artistic integrity and message clarity. Successful creators often develop platform-specific variations of core content rather than using identical content across all channels.
             </p>
 
-            <h3 className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Portfolio and Professional Presentation</h3>
+            <h3 className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Portfolio and Professional Presentation</h3>
             <p>
               Creative professionals require sophisticated presentation strategies that showcase technical skills, artistic vision, and professional capabilities to potential clients and collaborators. Portfolio organization, case study development, and project documentation help communicate creative process and problem-solving abilities alongside finished creative work.
             </p>
@@ -190,7 +190,7 @@ export default function CreativeGifDesignTutorial() {
 
             <h2 id="trends" className="text-3xl font-bold text-blue-700 mt-12 mb-6">Emerging Trends and Future Directions</h2>
 
-            <h3 className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Interactive and Responsive Design</h3>
+            <h3 className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Interactive and Responsive Design</h3>
             <p>
               Future GIF design increasingly incorporates interactive elements, responsive behaviors, and personalization features that adapt to viewer preferences and contexts. These developments expand creative possibilities while maintaining the accessibility and compatibility advantages that make GIFs universally effective across diverse platforms and devices.
             </p>
@@ -198,7 +198,7 @@ export default function CreativeGifDesignTutorial() {
               Emerging technologies including artificial intelligence, machine learning, and advanced web standards enable new creative techniques while automating routine production tasks. Understanding these technological trends helps creative professionals adapt their skills and workflows to remain competitive in evolving creative markets.
             </p>
 
-            <h3 className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Sustainability and Accessibility</h3>
+            <h3 className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Sustainability and Accessibility</h3>
             <p>
               Modern creative practice increasingly emphasizes sustainability considerations including energy efficiency, accessibility compliance, and inclusive design principles. These requirements often inspire creative innovations rather than limiting artistic expression, leading to more thoughtful and broadly appealing creative solutions.
             </p>

--- a/src/pages/blog/GifAccessibilityGuide.jsx
+++ b/src/pages/blog/GifAccessibilityGuide.jsx
@@ -105,7 +105,7 @@ export default function GifAccessibilityGuide() {
               Safe animation practices include avoiding rapid color changes, high-contrast flashing, and repetitive geometric patterns that can trigger seizures. When creating content that might approach these thresholds, testing with photosensitive epilepsy analysis tools helps identify potential risks before publication. Additionally, providing user controls to disable animation gives viewers agency over their experience.
             </p>
 
-            <h3 id="seizure-technical" className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Technical Implementation of Seizure Safety</h3>
+            <h3 id="seizure-technical" className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Technical Implementation of Seizure Safety</h3>
             <p>
               Implementing seizure-safe animation requires systematic analysis of flash frequency, color contrast changes, and pattern movement throughout the entire animation sequence. Automated testing tools can identify potential violations, but manual review by accessibility experts provides additional assurance, particularly for complex or artistic content that might not conform to typical patterns.
             </p>
@@ -115,7 +115,7 @@ export default function GifAccessibilityGuide() {
 
             <h2 id="visual" className="text-3xl font-bold text-blue-700 mt-12 mb-6">Visual Accessibility and Low Vision Considerations</h2>
 
-            <h3 className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Color and Contrast Optimization</h3>
+            <h3 className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Color and Contrast Optimization</h3>
             <p>
               Visual accessibility requires careful attention to color choices, contrast ratios, and visual hierarchy that ensure content remains perceivable across different vision conditions. WCAG guidelines specify minimum contrast ratios of 4.5:1 for normal text and 3:1 for large text, but animated content often requires higher contrast ratios to remain legible during motion and color transitions.
             </p>
@@ -123,7 +123,7 @@ export default function GifAccessibilityGuide() {
               Color-blind accessibility ensures that information conveyed through color is also available through other visual cues such as shape, position, texture, or text labels. Approximately 8% of men and 0.5% of women have some form of color vision deficiency, making this consideration essential for broad accessibility. Testing with color blindness simulation tools helps identify potential issues during the design phase.
             </p>
 
-            <h3 id="typography" className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Typography and Text Legibility</h3>
+            <h3 id="typography" className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Typography and Text Legibility</h3>
             <p>
               Animated text requires special consideration for users with low vision or reading difficulties. Font choices should prioritize clarity over decoration, with sans-serif fonts generally providing better legibility in animated contexts. Text size, spacing, and duration must allow comfortable reading for users who may need additional time to process visual information.
             </p>
@@ -133,7 +133,7 @@ export default function GifAccessibilityGuide() {
 
             <h2 id="cognitive" className="text-3xl font-bold text-blue-700 mt-12 mb-6">Cognitive Accessibility and Information Processing</h2>
 
-            <h3 className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Content Complexity and Comprehension</h3>
+            <h3 className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Content Complexity and Comprehension</h3>
             <p>
               Cognitive accessibility ensures that animated content can be understood by users with various cognitive processing capabilities, including those with attention deficit disorders, learning disabilities, and processing speed differences. This requires careful attention to information density, pacing, and cognitive load management throughout the animation sequence.
             </p>
@@ -141,7 +141,7 @@ export default function GifAccessibilityGuide() {
               Effective cognitive accessibility techniques include providing clear visual hierarchy, limiting simultaneous information sources, using consistent visual and interaction patterns, and allowing users to control pacing through pause, replay, and speed controls. Complex animations should be broken into digestible segments with clear progression indicators and optional detailed explanations.
             </p>
 
-            <h3 id="attention" className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Attention and Focus Management</h3>
+            <h3 id="attention" className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Attention and Focus Management</h3>
             <p>
               Animated content must manage viewer attention thoughtfully to avoid overwhelming users with attention difficulties while maintaining engagement for all viewers. Techniques include using motion purposefully to guide attention, avoiding competing motion elements, providing clear focal points, and implementing logical progression through animated sequences.
             </p>
@@ -151,7 +151,7 @@ export default function GifAccessibilityGuide() {
 
             <h2 id="assistive" className="text-3xl font-bold text-blue-700 mt-12 mb-6">Assistive Technology Compatibility</h2>
 
-            <h3 id="screen-reader" className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Screen Reader Integration</h3>
+            <h3 id="screen-reader" className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Screen Reader Integration</h3>
             <p>
               Screen readers and other assistive technologies require proper markup and alternative content to convey animated information to users who cannot see visual content. This includes descriptive alt text that explains both the visual content and any motion or changes that occur throughout the animation sequence. Simple descriptions like "loading animation" are insufficient for complex animated content.
             </p>
@@ -159,7 +159,7 @@ export default function GifAccessibilityGuide() {
               Advanced screen reader support may include time-based descriptions that correspond to animation phases, structured markup that identifies animation regions, and programmatic indicators of animation status (playing, paused, completed). These technical implementations ensure that users of assistive technologies receive equivalent information to visual users.
             </p>
 
-            <h3 id="keyboard" className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Keyboard and Alternative Input Methods</h3>
+            <h3 id="keyboard" className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Keyboard and Alternative Input Methods</h3>
             <p>
               Interactive GIF elements must be accessible through keyboard navigation and alternative input methods for users who cannot use mouse or touch interfaces. This includes providing keyboard shortcuts for play/pause controls, implementing logical tab order for interactive elements, and ensuring all functionality is available through keyboard-only interaction.
             </p>
@@ -169,7 +169,7 @@ export default function GifAccessibilityGuide() {
 
             <h2 id="technical" className="text-3xl font-bold text-blue-700 mt-12 mb-6">Technical Implementation Strategies</h2>
 
-            <h3 id="responsive" className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Responsive and Adaptive Design</h3>
+            <h3 id="responsive" className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Responsive and Adaptive Design</h3>
             <p>
               Accessible GIF implementation often requires multiple versions optimized for different user needs and technical capabilities. This may include high-contrast versions for low vision users, reduced-motion versions for users with vestibular disorders, and static alternatives for users who cannot access animated content. Systematic version management ensures all users receive appropriate content without imposing additional cognitive load.
             </p>
@@ -177,7 +177,7 @@ export default function GifAccessibilityGuide() {
               Progressive enhancement strategies deliver basic accessible content to all users while adding enhanced features for capable browsers and devices. This approach ensures universal access while taking advantage of advanced capabilities where available. Feature detection and graceful degradation help maintain accessibility across diverse technology environments.
             </p>
 
-            <h3 id="preferences" className="text-2xl font-semibent text-gray-800 mt-8 mb-4">User Preference Integration</h3>
+            <h3 id="preferences" className="text-2xl font-semibold text-gray-800 mt-8 mb-4">User Preference Integration</h3>
             <p>
               Modern accessibility implementation includes respecting user-defined preferences through system settings and browser configurations. The CSS prefers-reduced-motion media query allows websites to automatically serve reduced-motion alternatives to users who have indicated preference for minimal animation. Similarly, prefers-color-scheme helps deliver appropriate color schemes for users with specific visual needs.
             </p>
@@ -194,7 +194,7 @@ export default function GifAccessibilityGuide() {
 
             <h2 id="testing" className="text-3xl font-bold text-blue-700 mt-12 mb-6">Testing and Quality Assurance</h2>
 
-            <h3 id="automated" className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Automated and Manual Testing Approaches</h3>
+            <h3 id="automated" className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Automated and Manual Testing Approaches</h3>
             <p>
               Comprehensive accessibility testing combines automated tools with manual evaluation and user testing. Automated tools efficiently identify technical violations like insufficient contrast or missing alternative text, while manual testing evaluates user experience quality and identifies issues that automated tools cannot detect. Both approaches are essential for thorough accessibility assurance.
             </p>
@@ -202,7 +202,7 @@ export default function GifAccessibilityGuide() {
               Manual testing should include keyboard-only navigation, screen reader interaction, and testing with users who have various disabilities. This human-centered approach reveals practical accessibility challenges and usage patterns that inform design improvements beyond basic compliance requirements.
             </p>
 
-            <h3 id="improvement" className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Continuous Improvement and Feedback Integration</h3>
+            <h3 id="improvement" className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Continuous Improvement and Feedback Integration</h3>
             <p>
               Accessibility is an ongoing process rather than a one-time achievement. Regular auditing, user feedback collection, and iterative improvement ensure that accessibility standards evolve with changing user needs and technological capabilities. Establishing feedback channels specifically for accessibility concerns helps identify real-world usage issues that might not emerge during formal testing.
             </p>
@@ -212,7 +212,7 @@ export default function GifAccessibilityGuide() {
 
             <h2 id="impact" className="text-3xl font-bold text-blue-700 mt-12 mb-6">Business and Social Impact</h2>
 
-            <h3 id="market" className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Market Reach and Business Benefits</h3>
+            <h3 id="market" className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Market Reach and Business Benefits</h3>
             <p>
               Accessible design expands market reach to the 15% of the global population living with disabilities, representing a trillion-dollar market opportunity. Beyond direct market expansion, accessible content often provides better user experiences for all users, improving overall engagement metrics, search engine rankings, and brand reputation among increasingly socially conscious consumers.
             </p>
@@ -220,7 +220,7 @@ export default function GifAccessibilityGuide() {
               Research demonstrates that accessible websites perform better across multiple business metrics including user satisfaction, task completion rates, and conversion performance. These benefits extend beyond disability communities to include aging populations, temporary impairments, and situational limitations that affect all users at various times.
             </p>
 
-            <h3 id="brand" className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Social Responsibility and Brand Impact</h3>
+            <h3 id="brand" className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Social Responsibility and Brand Impact</h3>
             <p>
               Commitment to accessibility demonstrates corporate values that resonate with employees, customers, and stakeholders who increasingly prioritize social responsibility in business relationships. Accessibility excellence can become a competitive differentiator that attracts talent, customers, and partnerships while contributing to positive social impact.
             </p>
@@ -230,7 +230,7 @@ export default function GifAccessibilityGuide() {
 
             <h2 id="future" className="text-3xl font-bold text-blue-700 mt-12 mb-6">Future Trends and Emerging Standards</h2>
 
-            <h3 id="technology" className="text-2xl font-semibent text-gray-800 mt-8 mb-4">Technology Evolution and Accessibility</h3>
+            <h3 id="technology" className="text-2xl font-semibold text-gray-800 mt-8 mb-4">Technology Evolution and Accessibility</h3>
             <p>
               Emerging technologies including artificial intelligence, virtual reality, and advanced web standards create new accessibility opportunities while introducing novel challenges. AI-powered image description, automatic captioning, and personalized accessibility features promise to improve access while requiring careful implementation to avoid introducing bias or excluding certain user groups.
             </p>


### PR DESCRIPTION
## Summary
- replace incorrect `font-semibent` class with `font-semibold` in blog post headings

## Testing
- `npm run lint`
- `npm run build` (fails: Cannot find module @rollup/rollup-linux-x64-gnu)
- `npm run dev` (fails: Cannot find module @rollup/rollup-linux-x64-gnu)

------
https://chatgpt.com/codex/tasks/task_e_68a48653b34c8329b9bfc49eebeeebea