### PR TITLE
Add tests for useIsMobile hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
   "assets:webp": "node scripts/generate-webp-heroes.js",
-  "assets:og": "node scripts/rasterize-og-image.js"
+  "assets:og": "node scripts/rasterize-og-image.js",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
@@ -80,7 +81,9 @@
     "svgo": "^4.0.0",
     "terser": "^5.43.1",
     "tw-animate-css": "^1.2.9",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "@testing-library/react": "^16.0.0",
+    "vitest": "^2.1.1"
   },
   "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af"
 }

--- a/src/hooks/use-mobile.test.js
+++ b/src/hooks/use-mobile.test.js
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, test, vi, afterEach } from 'vitest'
+import { useIsMobile } from './use-mobile'
+
+describe('useIsMobile', () => {
+  const originalMatchMedia = window.matchMedia
+  const originalInnerWidth = window.innerWidth
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia
+    window.innerWidth = originalInnerWidth
+    vi.restoreAllMocks()
+  })
+
+  test('returns false/true based on screen width', () => {
+    let changeHandler
+    const mqlMock = {
+      addEventListener: vi.fn((_, cb) => {
+        changeHandler = cb
+      }),
+      removeEventListener: vi.fn(),
+    }
+    window.matchMedia = vi.fn().mockReturnValue(mqlMock)
+
+    window.innerWidth = 800
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(false)
+
+    window.innerWidth = 500
+    act(() => {
+      changeHandler()
+    })
+    expect(result.current).toBe(true)
+  })
+
+  test('cleans up change listener on unmount', () => {
+    let changeHandler
+    const mqlMock = {
+      addEventListener: vi.fn((_, cb) => {
+        changeHandler = cb
+      }),
+      removeEventListener: vi.fn(),
+    }
+    window.matchMedia = vi.fn().mockReturnValue(mqlMock)
+
+    window.innerWidth = 800
+    const { unmount } = renderHook(() => useIsMobile())
+    unmount()
+
+    expect(mqlMock.removeEventListener).toHaveBeenCalledWith('change', changeHandler)
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for `useIsMobile` hook
- configure vitest and testing library

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.4.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a486875f30832990d6bab37033ff66