### PR TITLE
chore: optimize build for modern browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
     <link rel="preload" href="/src/main.jsx" as="script" type="module">
     <link rel="preload" href="/og-image.png" as="image">
     <link rel="preload" href="/favicon.svg" as="image">
+    <link rel="preload" href="/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin>
     
   <!-- Preconnect for performance -->
     <link rel="preconnect" href="https://www.googletagmanager.com" />

--- a/vite.config.js
+++ b/vite.config.js
@@ -76,7 +76,14 @@ export default defineConfig({
     chunkSizeWarningLimit: 1000,
     cssCodeSplit: true,
     sourcemap: true,
-    target: 'es2015',
+    target: 'esnext',
+    modulePreload: { polyfill: false },
+    minify: 'terser',
+    terserOptions: {
+      compress: {
+        drop_console: true,
+      },
+    },
   },
   optimizeDeps: {
     include: ['react', 'react-dom', 'lucide-react', 'react-router-dom'],


### PR DESCRIPTION
## Summary
- preload Inter webfont to avoid invisible text
- target modern browsers and drop console output for smaller bundles

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found; installation blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a49ad0bd1083299b15b75e6e0d887d