### PR TITLE
chore: expand GIF Maker SEO keywords

### DIFF
--- a/src/tools/GifMakerTool.jsx
+++ b/src/tools/GifMakerTool.jsx
@@ -192,7 +192,7 @@ export default function GifMakerTool() {
       seoProps={{
         title: "GIF Maker - Create Animated GIFs from Images | EasyGIFMaker",
         description: "Create animated GIFs from multiple images online for free. Upload images, set custom timing, and generate high-quality GIFs instantly. No registration required.",
-        keywords: "gif maker, animated gif maker, make a gif from photos, make your own gif, create gif from images, create your own gif, make a gif from pictures, create a gif from pictures, gif creator, gif builder, custom gif, high quality gif maker, free gif maker, online gif maker, gif creator online, gif maker app, make my own gif, easy gif animator",
+        keywords: "gif maker, animated gif maker, make a gif from photos, make your own gif, create gif from images, create your own gif, make a gif from pictures, create a gif from pictures, gif creator, gif builder, custom gif, high quality gif maker, free gif maker, online gif maker, gif creator online, gif maker app, make my own gif, easy gif animator, gifmaker, gif maker free, gif maker online free, make a gif, gif animation maker, EZ GIF maker alternative",
         canonical: "https://easygifmaker.com/gif-maker"
       }}
       howToSteps={[


### PR DESCRIPTION
## Summary
- broaden GIF Maker SEO keywords to capture more search queries

## Testing
- `npm run lint`
- `npx vitest` *(fails: 403 Forbidden when fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68a89086a6388329b9ab2625367f1a9d