### PR TITLE
feat: support video segments with brightness controls

### DIFF
--- a/src/components/VideoTimeline.jsx
+++ b/src/components/VideoTimeline.jsx
@@ -8,7 +8,9 @@ export default function VideoTimeline({
   videoUrl,
   onSegmentChange,
   segmentRange, // Now controlled by parent
-  setSegmentRange // Now controlled by parent
+  setSegmentRange, // Now controlled by parent
+  brightness = 0,
+  contrast = 1
 }) {
   const videoRef = useRef(null)
   const [isPlaying, setIsPlaying] = useState(false)
@@ -138,6 +140,7 @@ export default function VideoTimeline({
           className="w-full h-auto max-h-96 object-contain"
           controls={false}
           preload="metadata"
+          style={{ filter: `brightness(${1 + brightness}) contrast(${contrast})` }}
         />
         {/* Custom Video Controls Overlay */}
         <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-4">


### PR DESCRIPTION
## Summary
- allow editing multiple video segments with Add Segment UI
- add brightness and contrast sliders with preview filters
- submit segments and filter settings with GIF conversion request

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ac55cb56cc8329808d0f7106a3f9e3