### PR TITLE
Defer API health check until after DOM ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       img { image-rendering: -webkit-optimize-contrast !important; }
     }
     </style>
-    <link rel="preload" href="/api/health" as="fetch" crossorigin>
+    <!-- Health check deferred to avoid blocking initial load -->
     <link rel="dns-prefetch" href="//fonts.googleapis.com">
     <link rel="dns-prefetch" href="//cdn.jsdelivr.net">
     <meta name="theme-color" content="#3b82f6">
@@ -67,9 +67,14 @@
     <script defer>
       window.addEventListener('DOMContentLoaded', function() {
         window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
+        function gtag(){dataLayer.push(arguments);}   
         gtag('js', new Date());
         gtag('config', 'G-4184BKX5QY', { 'anonymize_ip': true });
+      });
+    </script>
+    <script>
+      window.addEventListener('DOMContentLoaded', function () {
+        fetch('/api/health').catch(() => {});
       });
     </script>
     <script>


### PR DESCRIPTION
## Summary
- remove preload request for `/api/health`
- trigger API health check after `DOMContentLoaded`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ada5d9ee448329936e907778e092e2