### PR TITLE
feat: lazy load rare icons

### DIFF
--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,29 +1,48 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Meta from '@/components/Meta.jsx';
 import { Link } from 'react-router-dom';
-import { Zap, Shield, Smile, Gift } from 'lucide-react';
+const GiftIcon = lazy(() => import('lucide-react/dist/esm/icons/gift'));
+const ShieldIcon = lazy(() => import('lucide-react/dist/esm/icons/shield'));
+const SmileIcon = lazy(() => import('lucide-react/dist/esm/icons/smile'));
+const ZapIcon = lazy(() => import('lucide-react/dist/esm/icons/zap'));
 import { Button } from '@/components/ui/button';
 
 export default function About() {
   const features = [
     {
-      icon: <Gift className="h-8 w-8 text-blue-600" />,
+      icon: (
+        <Suspense fallback={<div className="h-8 w-8" />}>
+          <GiftIcon className="h-8 w-8 text-blue-600" />
+        </Suspense>
+      ),
       title: 'Comprehensive Tools',
       description: 'From video conversion to adding text, we provide a full suite of tools to bring your GIFs to life.'
     },
     {
-      icon: <Shield className="h-8 w-8 text-green-600" />,
+      icon: (
+        <Suspense fallback={<div className="h-8 w-8" />}>
+          <ShieldIcon className="h-8 w-8 text-green-600" />
+        </Suspense>
+      ),
       title: 'Privacy First',
       description: 'We never store your files. Everything you upload is processed securely and deleted automatically.'
     },
     {
-      icon: <Smile className="h-8 w-8 text-purple-600" />,
+      icon: (
+        <Suspense fallback={<div className="h-8 w-8" />}>
+          <SmileIcon className="h-8 w-8 text-purple-600" />
+        </Suspense>
+      ),
       title: 'Simple & User-Friendly',
       description: 'Our tools are designed to be intuitive and easy to use for everyone, no technical skills required.'
     },
     {
-      icon: <Zap className="h-8 w-8 text-orange-600" />,
+      icon: (
+        <Suspense fallback={<div className="h-8 w-8" />}>
+          <ZapIcon className="h-8 w-8 text-orange-600" />
+        </Suspense>
+      ),
       title: 'Free & Fast',
       description: 'Enjoy unlimited access to all our tools for free, with fast processing and no watermarks.'
     }

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -1,8 +1,20 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Meta from '@/components/Meta.jsx';
 import { Link } from 'react-router-dom';
-import { Calendar, User, ArrowRight, BookOpen, Sparkles } from 'lucide-react';
+const CalendarIcon = lazy(() => import('lucide-react/dist/esm/icons/calendar'));
+const UserIcon = lazy(() => import('lucide-react/dist/esm/icons/user'));
+const ArrowRightIcon = lazy(() => import('lucide-react/dist/esm/icons/arrow-right'));
+const BookOpenIcon = lazy(() => import('lucide-react/dist/esm/icons/book-open'));
+const SparklesIcon = lazy(() => import('lucide-react/dist/esm/icons/sparkles'));
+
+function LazyIcon({ icon: Icon, className }) {
+  return (
+    <Suspense fallback={<div className={className} />}>
+      <Icon className={className} />
+    </Suspense>
+  );
+}
 
 // Example blog posts data with featured images
 const blogPosts = [
@@ -254,8 +266,8 @@ export default function Blog() {
 						</div>
 						<div className="relative z-10">
 							<div className="flex items-center justify-center gap-3 mb-6">
-								<BookOpen className="w-12 h-12 text-blue-600" />
-								<Sparkles className="w-8 h-8 text-purple-500" />
+                                                            <LazyIcon icon={BookOpenIcon} className="w-12 h-12 text-blue-600" />
+                                                            <LazyIcon icon={SparklesIcon} className="w-8 h-8 text-purple-500" />
 							</div>
 							<h1 className="text-5xl md:text-7xl font-extrabold bg-gradient-to-r from-blue-700 via-purple-600 to-blue-800 bg-clip-text text-transparent mb-6 drop-shadow-sm tracking-tight">
 								EasyGIFMaker Blog
@@ -266,14 +278,14 @@ export default function Blog() {
 								the most of EasyGIFMaker!
 							</p>
 							<div className="flex items-center justify-center gap-6 text-sm text-gray-600">
-								<span className="flex items-center gap-2">
-									<Calendar className="w-4 h-4" />
-									Latest: {featuredPost?.date}
-								</span>
-								<span className="flex items-center gap-2">
-									<User className="w-4 h-4" />
-									{blogPosts.length} Articles
-								</span>
+                                                                <span className="flex items-center gap-2">
+                                                                        <LazyIcon icon={CalendarIcon} className="w-4 h-4" />
+                                                                        Latest: {featuredPost?.date}
+                                                                </span>
+                                                                <span className="flex items-center gap-2">
+                                                                        <LazyIcon icon={UserIcon} className="w-4 h-4" />
+                                                                        {blogPosts.length} Articles
+                                                                </span>
 							</div>
 						</div>
 					</header>
@@ -304,10 +316,10 @@ export default function Blog() {
 										</div>
 										<div className="md:w-1/2 p-8 flex flex-col justify-center">
 											<div className="flex items-center gap-2 text-sm text-gray-500 mb-4">
-												<Calendar className="w-4 h-4" />
+                                                                                                <LazyIcon icon={CalendarIcon} className="w-4 h-4" />
 												<time dateTime={featuredPost.date}>{featuredPost.date}</time>
 												<span>•</span>
-												<User className="w-4 h-4" />
+                                                                                                <LazyIcon icon={UserIcon} className="w-4 h-4" />
 												{featuredPost.author}
 											</div>
 											<h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-4 leading-tight">
@@ -332,7 +344,7 @@ export default function Blog() {
 												aria-label={`Read more about ${featuredPost.title}`}
 											>
 												Read Full Article
-												<ArrowRight className="w-4 h-4" />
+                                                                                                <LazyIcon icon={ArrowRightIcon} className="w-4 h-4" />
 											</Link>
 										</div>
 									</div>
@@ -364,10 +376,10 @@ export default function Blog() {
 										</div>
 										<div className="p-6">
 											<div className="flex items-center gap-2 text-sm text-gray-500 mb-3">
-												<Calendar className="w-4 h-4" />
+                                                                                                <LazyIcon icon={CalendarIcon} className="w-4 h-4" />
 												<time dateTime={post.date}>{post.date}</time>
 												<span>•</span>
-												<User className="w-4 h-4" />
+                                                                                                <LazyIcon icon={UserIcon} className="w-4 h-4" />
 												{post.author}
 											</div>
 											<h3
@@ -395,7 +407,7 @@ export default function Blog() {
 												aria-label={`Read more about ${post.title}`}
 											>
 												Read More
-												<ArrowRight className="w-4 h-4" />
+                                                                                                <LazyIcon icon={ArrowRightIcon} className="w-4 h-4" />
 											</Link>
 										</div>
 									</article>
@@ -423,14 +435,14 @@ export default function Blog() {
 									className="inline-flex items-center gap-2 px-8 py-3 bg-white text-blue-600 font-bold rounded-full shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105"
 								>
 									Try GIF Maker
-									<ArrowRight className="w-4 h-4" />
+                                                                        <LazyIcon icon={ArrowRightIcon} className="w-4 h-4" />
 								</Link>
 								<Link
 									to="/video-to-gif"
 									className="inline-flex items-center gap-2 px-8 py-3 border-2 border-white text-white font-bold rounded-full hover:bg-white hover:text-blue-600 transition-all duration-300"
 								>
 									Video to GIF
-									<ArrowRight className="w-4 h-4" />
+                                                                        <LazyIcon icon={ArrowRightIcon} className="w-4 h-4" />
 								</Link>
 							</div>
 						</section>

--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -1,37 +1,52 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Meta from '@/components/Meta.jsx';
 import { Link } from 'react-router-dom';
-import { BookOpen, Video, Image, Scissors, Type, Zap, Download, Share2, Smartphone, Monitor } from 'lucide-react';
+const VideoIcon = lazy(() => import('lucide-react/dist/esm/icons/video'));
+const ImageIcon = lazy(() => import('lucide-react/dist/esm/icons/image'));
+const ScissorsIcon = lazy(() => import('lucide-react/dist/esm/icons/scissors'));
+const TypeIcon = lazy(() => import('lucide-react/dist/esm/icons/type'));
+const ZapIcon = lazy(() => import('lucide-react/dist/esm/icons/zap'));
+const Share2Icon = lazy(() => import('lucide-react/dist/esm/icons/share-2'));
+const SmartphoneIcon = lazy(() => import('lucide-react/dist/esm/icons/smartphone'));
+const MonitorIcon = lazy(() => import('lucide-react/dist/esm/icons/monitor'));
+
+function LazyIcon({ icon: Icon, className }) {
+  return (
+    <Suspense fallback={<div className={className} />}>
+      <Icon className={className} />
+    </Suspense>
+  );
+}
 
 export default function Help() {
   const helpCategories = [
     {
-      icon: <Video className="h-6 w-6 text-blue-600" />,
+      icon: <LazyIcon icon={VideoIcon} className="h-6 w-6 text-blue-600" />,
       title: 'Video to GIF Conversion',
       description: 'Learn how to convert videos into high-quality GIFs',
       link: '/blog/how-to-make-gifs-from-videos'
     },
     {
-      icon: <Image className="h-6 w-6 text-green-600" />,
+      icon: <LazyIcon icon={ImageIcon} className="h-6 w-6 text-green-600" />,
       title: 'GIF Creation from Images',
       description: 'Create animated GIFs from multiple static images',
       link: '/gif-maker'
     },
     {
-      icon: <Scissors className="h-6 w-6 text-purple-600" />,
+      icon: <LazyIcon icon={ScissorsIcon} className="h-6 w-6 text-purple-600" />,
       title: 'GIF Cropping & Resizing',
       description: 'Crop and resize your GIFs for different platforms',
       link: '/crop'
     },
     {
-      icon: <Type className="h-6 w-6 text-orange-600" />,
+      icon: <LazyIcon icon={TypeIcon} className="h-6 w-6 text-orange-600" />,
       title: 'Adding Text to GIFs',
       description: 'Add captions, watermarks, and text overlays',
       link: '/add-text'
     },
     {
-      icon: <Zap className="h-6 w-6 text-red-600" />,
+      icon: <LazyIcon icon={ZapIcon} className="h-6 w-6 text-red-600" />,
       title: 'GIF Optimization',
       description: 'Optimize GIFs for faster loading and better quality',
       link: '/optimize'
@@ -89,7 +104,7 @@ export default function Help() {
   const platformGuides = [
     {
       platform: 'Social Media',
-      icon: <Share2 className="h-5 w-5" />,
+      icon: <LazyIcon icon={Share2Icon} className="h-5 w-5" />,
       tips: [
         'Twitter: Keep under 5MB, use 15fps',
         'Instagram: Square format (1:1 ratio) works best',
@@ -99,7 +114,7 @@ export default function Help() {
     },
     {
       platform: 'Websites',
-      icon: <Monitor className="h-5 w-5" />,
+      icon: <LazyIcon icon={MonitorIcon} className="h-5 w-5" />,
       tips: [
         'Use 640x480 resolution for fast loading',
         'Keep file size under 2MB',
@@ -109,7 +124,7 @@ export default function Help() {
     },
     {
       platform: 'Mobile',
-      icon: <Smartphone className="h-5 w-5" />,
+      icon: <LazyIcon icon={SmartphoneIcon} className="h-5 w-5" />,
       tips: [
         'Use 320x240 resolution for messaging',
         'Keep under 2MB for reliable sharing',

--- a/src/pages/blog/CompleteGuideToResizeGif.jsx
+++ b/src/pages/blog/CompleteGuideToResizeGif.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Meta from '@/components/Meta.jsx';
 import { Link } from 'react-router-dom';
 import DisplayAd from '@/components/ads/DisplayAd.jsx';
 import InArticleAd from '@/components/ads/InArticleAd.jsx';
-import { Maximize2 } from 'lucide-react';
+const Maximize2Icon = lazy(() => import('lucide-react/dist/esm/icons/maximize-2'));
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card.jsx';
 import AdsenseAd from '@/components/AdsenseAd.jsx';
 
@@ -90,7 +90,9 @@ export default function CompleteGuideToResizeGif() {
           <CardHeader className="pb-6">
             <div className="flex items-center gap-3 mb-4">
               <div className="p-3 bg-gradient-to-r from-blue-500 to-purple-500 rounded-xl">
-                <Maximize2 className="h-6 w-6 text-white" />
+                <Suspense fallback={<div className="h-6 w-6" />}>
+                  <Maximize2Icon className="h-6 w-6 text-white" />
+                </Suspense>
               </div>
               <div>
                 <CardTitle className="text-3xl font-bold text-gray-800">

--- a/src/pages/blog/MasterTheArtofAddingTextToGIFs.jsx
+++ b/src/pages/blog/MasterTheArtofAddingTextToGIFs.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Meta from '@/components/Meta.jsx';
 import { Link } from 'react-router-dom';
-import { Type } from 'lucide-react';
+const TypeIcon = lazy(() => import('lucide-react/dist/esm/icons/type'));
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card.jsx'
 
 export default function MasterTheArtofAddingTextToGIFs() {
@@ -83,7 +83,9 @@ export default function MasterTheArtofAddingTextToGIFs() {
             <CardHeader className="pb-6">
               <div className="flex items-center gap-3 mb-4">
                 <div className="p-3 bg-gradient-to-r from-blue-500 to-purple-500 rounded-xl">
-                  <Type className="h-6 w-6 text-white" />
+                <Suspense fallback={<div className="h-6 w-6" />}>
+                  <TypeIcon className="h-6 w-6 text-white" />
+                </Suspense>
                 </div>
                 <div>
                   <CardTitle className="text-3xl font-bold text-gray-800">

--- a/src/pages/blog/ProfessionalGIFCroppingandCompositionGuide.jsx
+++ b/src/pages/blog/ProfessionalGIFCroppingandCompositionGuide.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Meta from '@/components/Meta.jsx';
 import { Link } from 'react-router-dom';
-import { Crop } from 'lucide-react';
+const CropIcon = lazy(() => import('lucide-react/dist/esm/icons/crop'));
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card.jsx'
 
 export default function ProfessionalGIFCroppingandCompositionGuide() {
@@ -81,7 +81,9 @@ export default function ProfessionalGIFCroppingandCompositionGuide() {
             <CardHeader className="pb-6">
               <div className="flex items-center gap-3 mb-4">
                 <div className="p-3 bg-gradient-to-r from-blue-500 to-purple-500 rounded-xl">
-                  <Crop className="h-6 w-6 text-white" />
+                <Suspense fallback={<div className="h-6 w-6" />}>
+                  <CropIcon className="h-6 w-6 text-white" />
+                </Suspense>
                 </div>
                 <div>
                   <CardTitle className="text-3xl font-bold text-gray-800">


### PR DESCRIPTION
## Summary
- dynamically import lucide icons on less-visited pages
- add generic LazyIcon wrapper for help and blog pages

## Testing
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.4.1.tgz)*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ada63dc1d88329ae9bd284ab782511