### PR TITLE
chore: configure modern build and legacy output

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,9 +81,18 @@
     "svgo": "^4.0.0",
     "terser": "^5.43.1",
     "tw-animate-css": "^1.2.9",
+    "@vitejs/plugin-legacy": "^5.4.0",
     "vite": "^6.3.5",
     "@testing-library/react": "^16.0.0",
     "vitest": "^2.1.1"
   },
+  "browserslist": [
+    "last 2 Chrome versions",
+    "last 2 Firefox versions",
+    "last 2 Safari versions",
+    "last 2 Edge versions",
+    "not IE 11",
+    "not op_mini all"
+  ],
   "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af"
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,7 @@ import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import viteCompression from 'vite-plugin-compression';
 import { ViteImageOptimizer } from 'vite-plugin-image-optimizer';
+import legacy from '@vitejs/plugin-legacy';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -25,6 +26,11 @@ export default defineConfig({
       jpeg: { quality: 80 },
       jpg: { quality: 80 },
       webp: { quality: 80 },
+    }),
+    legacy({
+      targets: ['defaults', 'not IE 11'],
+      modernPolyfills: false,
+      renderLegacyChunks: true,
     }),
   ],
   resolve: {


### PR DESCRIPTION
## Summary
- define browserslist for modern browsers
- configure Vite legacy plugin with modern target

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ada97fd96c8329b4ef2cdb1b1f25a9