### PR TITLE
Expand Netlify headers for subdirectory assets

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -16,6 +16,9 @@
 /*.webp
   Cache-Control: public, max-age=31536000, immutable
 
+/*/*.webp
+  Cache-Control: public, max-age=31536000, immutable
+
 /*.png
   Cache-Control: public, max-age=31536000, immutable
 
@@ -25,8 +28,17 @@
 /*.svg
   Cache-Control: public, max-age=31536000, immutable
 
+/*/*.svg
+  Cache-Control: public, max-age=31536000, immutable
+
 /*.woff2
   Cache-Control: public, max-age=31536000, immutable
+
+/ads.txt
+  Cache-Control: public, max-age=86400
+
+/sitemap.xml
+  Cache-Control: public, max-age=86400
 
 /fonts/*
   Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary
- handle `webp` and `svg` assets in nested directories via Netlify `_headers`
- add caching headers for `ads.txt` and `sitemap.xml`

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found; `npx vitest` returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ada97ce9008329a05459bf817e2a16