### PR TITLE
Defer inline scripts for non-blocking execution

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,13 +72,13 @@
         gtag('config', 'G-4184BKX5QY', { 'anonymize_ip': true });
       });
     </script>
-    <script>
+    <script defer>
       window.addEventListener('DOMContentLoaded', function () {
         fetch('/api/health').catch(() => {});
       });
     </script>
-    <script>
-      (function() {
+    <script defer>
+      window.addEventListener('DOMContentLoaded', function () {
         function removeBaseDescriptionWhenReady() {
           const base = document.querySelector('meta[name="description"]:not([data-rh])');
           const helmet = document.querySelector('meta[name="description"][data-rh="true"]');
@@ -89,12 +89,12 @@
           return false;
         }
         if (!removeBaseDescriptionWhenReady()) {
-          const mo = new MutationObserver(function() {
+          const mo = new MutationObserver(function () {
             if (removeBaseDescriptionWhenReady()) mo.disconnect();
           });
           mo.observe(document.head, { childList: true, subtree: true });
         }
-      })();
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- defer health check and meta description scripts so they run after DOM is interactive
- attach DOMContentLoaded handlers to avoid blocking rendering

## Testing
- `npm test` *(fails: vitest not found)*
- `pnpm test` *(fails: could not download pnpm)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ada97b14648329a2109803f15640c0